### PR TITLE
The bind command in the bash completion script causes x2go to not start anymore

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -31,7 +31,10 @@ fi
 ###########################################################
 
 # To redraw line after fzf closes (printf '\e[5n')
-bind '"\e[0n": redraw-current-line'
+if [ -t 1 ]
+then
+  bind '"\e[0n": redraw-current-line'
+fi
 
 __fzfcmd_complete() {
   [ -n "$TMUX_PANE" ] && [ "${FZF_TMUX:-0}" != 0 ] && [ ${LINES:-40} -gt 15 ] &&


### PR DESCRIPTION
I'm using x2go for remote access to a server. 
It seems that when starting the x2go desktop a shell is started without creating a pty. 

This causes the bind command to fail, and even though this should only a warning x2go treats it as an error.
The error is "bash bind warning: line editing not enabled" 
Checking whether the completion script is run in a terminal  solves this issue, see also
https://superuser.com/questions/892658/remote-ssh-commands-bash-bind-warning-line-editing-not-enabled